### PR TITLE
Added ‘char’ (c) and ‘asInt’ instances formatting Enum

### DIFF
--- a/src/Formatting/Formatters.hs
+++ b/src/Formatting/Formatters.hs
@@ -19,6 +19,7 @@ module Formatting.Formatters
   text,
   stext,
   string,
+  char,
   builder,
   fconst,
   -- * Numbers
@@ -32,6 +33,7 @@ module Formatting.Formatters
   shortest,
   commas,
   ords,
+  asInt,
   -- * Padding
   left,
   right,
@@ -73,6 +75,10 @@ stext = later T.fromText
 -- | Output a string.
 string :: Format String
 string = later (T.fromText . T.pack)
+
+-- | Output a character.
+char :: Format Char
+char = later (T.fromText . T.pack . return)
 
 -- | Build a builder.
 builder :: Format Builder
@@ -122,6 +128,13 @@ sci = later scientificBuilder
 -- | Render a scientific number with options.
 scifmt :: FPFormat -> Maybe Int -> Format Scientific
 scifmt f i = later (formatScientificBuilder f i)
+
+-- | Shows the Int value of Enum instances using 'fromEnum'.
+-- 
+-- >>> format ("Got: " % char % " (" % asInt % ")") 'a' 'a'
+-- "Got: a (97)"
+asInt :: Enum a => Format a
+asInt = later (T.shortest . fromEnum)
 
 -- | Pad the left hand side of a string until it reaches k characters
 -- wide, if necessary filling with character c.

--- a/src/Formatting/ShortFormatters.hs
+++ b/src/Formatting/ShortFormatters.hs
@@ -41,6 +41,10 @@ st = later T.fromText
 s :: Format String
 s = later (T.fromText . T.pack)
 
+-- | Output a character.
+c :: Format Char
+c = later (T.fromText . T.pack . return)
+
 -- | Render a floating point number using scientific/engineering
 -- notation (e.g. 2.3e123), with the given number of decimal places.
 ef :: Real a => Int -> Format a
@@ -62,12 +66,12 @@ pf i = later (T.prec i)
 sf :: Real a => Format a
 sf = later T.shortest
 
--- | Pad the left hand side of a string until it reaches k characters
--- wide, if necessary filling with character c.
+-- | Pad the left hand side of a string until it reaches @k@ characters
+-- wide, if necessary filling with character @ch@.
 l :: Buildable a => Int -> Char -> Format a
-l i c = later (T.left i c)
+l i ch = later (T.left i ch)
 
--- | Pad the right hand side of a string until it reaches k characters
--- wide, if necessary filling with character c.
+-- | Pad the right hand side of a string until it reaches @k@ characters
+-- wide, if necessary filling with character @ch@.
 r :: Buildable a => Int -> Char -> Format a
-r i c = later (T.right i c)
+r i ch = later (T.right i ch)


### PR DESCRIPTION
Simple character formatter and a formatter that formats values as an `Int` using `fromEnum`:

``` haskell
ghci> mapM_ TIO.putStrLn [ format (char % " has value " % asInt) ch ch | ch <- "abc" ]
a has value 97
b has value 98
c has value 99
```

As a vague motivator the Rust tutorial has an [examples](http://doc.rust-lang.org/tutorial.html#enums) of formatting using what is effectively `fromEnum`:

``` rust
println!( "North => {}", North as int );
```

which would be:

``` haskell
ghci> data Direction = South | North | East | West deriving Enum
ghci> format ("North => " % asInt) North
"North => 1"
```
