### PR TITLE
Hide import defaultTimeLocale from System.Locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+env:
+ - CABALVER=1.16 GHCVER=7.4.2
+ - CABALVER=1.16 GHCVER=7.6.3
+ - CABALVER=1.20 GHCVER=7.8.4
+ - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=head GHCVER=head
+
+matrix:
+  allow_failures:
+   - env: CABALVER=head GHCVER=head
+
+before_install:
+ - sudo add-apt-repository -y ppa:hvr/ghc
+ - sudo apt-get update -qq
+
+install:
+ - sudo apt-get install -qq cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH="/opt/cabal/$CABALVER/bin:/opt/ghc/$GHCVER/bin:$PATH"
+
+before_script:
+ - cabal --version
+ - cabal update
+ - ghc --version
+ - ghc-pkg list
+
+script:
+ - cabal install --enable-documentation
+ - cabal sdist
+
+after_script:
+ - ghc-pkg list

--- a/src/Formatting/Time.hs
+++ b/src/Formatting/Time.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -15,7 +16,11 @@ import           Data.Text              (Text)
 import qualified Data.Text              as T
 import           Data.Text.Buildable
 import           Data.Time
+#if __GLASGOW_HASKELL__ >= 710
+import           System.Locale hiding (defaultTimeLocale)
+#else
 import           System.Locale
+#endif
 
 -- * For 'TimeZone' (and 'ZonedTime' and 'UTCTime'):
 


### PR DESCRIPTION
Otherwise the reference is ambiguous in ghc 7.10 and formatting fails to build for me because of a API change in time >= 1.5.

Unfortunately I guess that means it would break for lower versions that have time < 1.5.

Best,
Markus