### PR TITLE
Check for min time version instead of ghc in CPP

### DIFF
--- a/src/Formatting/Time.hs
+++ b/src/Formatting/Time.hs
@@ -15,7 +15,7 @@ import           Data.Text              (Text)
 import qualified Data.Text              as T
 import           Data.Text.Buildable
 import           Data.Time
-#if __GLASGOW_HASKELL__ >= 710
+#if MIN_VERSION_time(1,5,0)
 import           System.Locale hiding (defaultTimeLocale)
 #else
 import           System.Locale


### PR DESCRIPTION
I introduced the GHC check via CPP, but actually this is not precise enough because using sandboxes you can have time > 1.5 with ghc 7.8.4.  This changes the check to look at the actual time version :)