### PR TITLE
Needs GHC >= 7.4 due to usage of Data.Monoid.<>

### DIFF
--- a/formatting.cabal
+++ b/formatting.cabal
@@ -20,7 +20,7 @@ library
                      Formatting.Time,
                      Formatting.Clock,
                      Formatting.Internal
-  build-depends:     base >= 4 && < 5,
+  build-depends:     base >= 4.5 && < 5,
                      text-format,
                      text >= 0.11.0.8,
                      time,


### PR DESCRIPTION
I've revised existing versions so a new release isn't needed, http://hackage.haskell.org/package/formatting/revisions/
