### PR TITLE
export `runFormat`

### DIFF
--- a/src/Formatting.hs
+++ b/src/Formatting.hs
@@ -27,6 +27,7 @@ module Formatting
   later,
   mapf,
   -- * Top-level functions
+  runFormat,
   format,
   sformat,
   bprint,


### PR DESCRIPTION
The formatting library provides a number of functions that use
formatters (format, sformat, bprint ...).  But it does not allow
to introduce user-defined functions like them (or I don't
understand how to do that).  For example, I would like to define
a formatted assert:

	fassert :: MonadThrow m => Bool -> Format (m ()) a -> a

With `runFormat` being exported it is easy:

	fassert a m = runFormat m $ when (not a) . throwM . AssertionFailed . TL.unpack . TLB.toLazyText

Then I can use it:

        fassert aValueThatShouldBeTrue ("some value: " % int) someValue