### PR TITLE
Reexport the guts of text-format as Formatting.Internal.Raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+6.3.3
+
+* The `Data.Text.Format` hierarchy was reexported as
+  `Formatting.Internal.Raw`.
+
 6.3.1
 
 * Proper GHC 7.10 -> GHC 8.4 support

--- a/formatting.cabal
+++ b/formatting.cabal
@@ -1,5 +1,5 @@
 name:                formatting
-version:             6.3.2
+version:             6.3.3
 synopsis:            Combinator-based type-safe formatting (like printf() or FORMAT)
 description:         Combinator-based type-safe formatting (like printf() or FORMAT), modelled from the HoleyMonoids package.
 license:             BSD3
@@ -21,6 +21,7 @@ library
     Formatting.Time
     Formatting.Clock
     Formatting.Internal
+    Formatting.Internal.Raw
     Formatting.Buildable
 
   other-modules:

--- a/src/Formatting/Internal/Raw.hs
+++ b/src/Formatting/Internal/Raw.hs
@@ -1,0 +1,14 @@
+-- | Reexports of things that were previously in the @text-format@ package.
+
+module Formatting.Internal.Raw
+  (
+  module Data.Text.Format,
+  module Data.Text.Format.Functions,
+  module Data.Text.Format.Int,
+  module Data.Text.Format.Types
+ ) where
+
+import Data.Text.Format
+import Data.Text.Format.Functions
+import Data.Text.Format.Int
+import Data.Text.Format.Types


### PR DESCRIPTION
Fixes #37.