### PR TITLE
Add overlappable 'Buildable a => Buildable [a]' instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+HEAD
+
+* Introduced instance `Buildable a => Buildable [a]`.
+
 6.3.3
 
 * The `Data.Text.Format` hierarchy was reexported as

--- a/src/Formatting/Buildable.hs
+++ b/src/Formatting/Buildable.hs
@@ -21,9 +21,10 @@ import qualified Data.ByteString.Lazy as L
 import           Data.Void (Void, absurd)
 #endif
 
-import           Data.Monoid (mempty)
+import           Data.Monoid (mempty, mconcat)
 import           Data.Int (Int8, Int16, Int32, Int64)
 import           Data.Fixed (Fixed, HasResolution, showFixed)
+import           Data.List (intersperse)
 import           Data.Ratio (Ratio, denominator, numerator)
 import qualified Data.Text.Format.Functions as F ((<>))
 import           Data.Text.Format.Int (decimal, hexadecimal, integer)
@@ -189,3 +190,10 @@ instance Buildable (Ptr a) where
 instance Buildable Bool where
     build True = fromText "True"
     build False = fromText "False"
+
+#if MIN_VERSION_base(4,8,0)
+instance {-# OVERLAPPABLE #-} Buildable a => Buildable [a] where
+    build = \xs -> "[" F.<> mconcat (intersperse "," (map build xs)) F.<> "]"
+    {-# INLINE build #-}
+#endif
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -60,3 +60,15 @@ spec = do
         it
           "Variable"
           (shouldBe (format float (12.123456 :: Double)) "12.123456"))
+
+  describe
+    "Buildable a => Buildable [a]"
+    (do it "\"\" :: [Char] (backwards compatibility)"
+           (shouldBe (format build ("" :: String)) "")
+        it "\"hi\" :: [Char] (backwards compatibility)"
+           (shouldBe (format build ("hi" :: String)) "hi")
+        it "[1,2,3] :: [Int]"
+           (shouldBe (format build ([1,2,3] :: [Int])) "[1,2,3]")
+        it "[] :: [Int]"
+           (shouldBe (format build ([] :: [Int])) "[]"))
+


### PR DESCRIPTION
The behavior of `Buildable [Char]` remains unchanged and ensured by tests.