### PR TITLE
Drop semigroups on GHC > 8.0

### DIFF
--- a/formatting.cabal
+++ b/formatting.cabal
@@ -55,7 +55,9 @@ test-suite formatting-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  build-depends:       base, formatting, hspec, semigroups, text
+  build-depends:       base, formatting, hspec, text
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
 
 source-repository head

--- a/formatting.cabal
+++ b/formatting.cabal
@@ -42,8 +42,10 @@ library
     text >= 0.11.0.8,
     transformers,
     bytestring >=0.10.4,
-    integer-gmp >= 0.2,
-    semigroups
+    integer-gmp >= 0.2
+
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups
 
   hs-source-dirs:    src
   ghc-options:       -O2


### PR DESCRIPTION
Data.Semigroup has been part of base since GHC 8.0
See https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode