### PR TITLE
Bring back `int :: Integral a => Format r (a -> r)`.

### DIFF
--- a/src/Formatting/Formatters.hs
+++ b/src/Formatting/Formatters.hs
@@ -108,8 +108,8 @@ build :: Buildable a => Format r (a -> r)
 build = later B.build
 
 -- | Render an integral e.g. 123 -> \"123\", 0 -> \"0\".
-int :: (Buildable a) => Format r (a -> r)
-int = later B.build
+int :: Integral a => Format r (a -> r)
+int = base 10
 
 -- | Render some floating point with the usual notation, e.g. 123.32 => \"123.32\"
 float :: Real a => Format r (a -> r)

--- a/src/Formatting/ShortFormatters.hs
+++ b/src/Formatting/ShortFormatters.hs
@@ -30,7 +30,7 @@ t :: Format r (Text -> r)
 t = later T.fromLazyText
 
 -- | Render an integral e.g. 123 -> \"123\", 0 -> \"0\".
-d :: (Buildable a) => Format r (a -> r)
+d :: Integral a => Format r (a -> r)
 d = int
 
 -- | Render an integer using binary notation. (No leading 0b is


### PR DESCRIPTION
The signatures of `int` changed over time from 

a8b939da30ffd82649506163a744e51364109664 `int :: Integral a => Format a`
3a55a3aa4d34cd3f9556c884f510b57e894154c7 `int :: Integral a => Format r (a -> r)`
7bd7a6138e157c1d67cf5b35e129443faa92b5b3 `int :: (Integral a, Show a) => Format r (a -> r)`
80d210966c3518d3a6de7cfa1549e2ddad8751f9 `int :: (Integral a, Buildable a) => Format r (a -> r)`
55c7adc3a2b3919c7f50fc1338f9b33ef2a2a342 `int :: (Buildable a) => Format r (a -> r)`

In the end `int` was synonymous to `build`.

This brings back `int` with `Integral a => Format r (a -> r)`.

Fixes #40, #43 