### PR TITLE
Add lower bounds to bytestring

### DIFF
--- a/formatting.cabal
+++ b/formatting.cabal
@@ -41,7 +41,7 @@ library
     ghc-prim,
     text >= 0.11.0.8,
     transformers,
-    bytestring,
+    bytestring >=0.10.4,
     integer-gmp >= 0.2,
     semigroups
 


### PR DESCRIPTION
We need Builder, and also doubleDec (which seems to be only >=0.10.4 in
Data.ByteString.Lazy.Builder)

I already made revisions for `formatting` on Hackage.